### PR TITLE
Better "do not root"

### DIFF
--- a/dockerfile-security.rego
+++ b/dockerfile-security.rego
@@ -66,7 +66,7 @@ deny[msg] {
     msg = sprintf("Line %d: Use COPY instead of ADD", [i])
 }
 
-# Do not root
+# Any user...
 any_user {
     input[i].Cmd == "user"
  }
@@ -74,6 +74,20 @@ any_user {
 deny[msg] {
     not any_user
     msg = "Do not run as root, use USER instead"
+}
+
+# ... but do not root
+forbidden_users = [
+    "root",
+    "toor",
+    "0"
+]
+
+deny[msg] {
+    input[i].Cmd == "user"
+    val := input[i].Value
+    contains(lower(val[_]), forbidden_users[_])
+    msg = sprintf("Line %d: Do not run as root: %s", [i, val])
 }
 
 # Do not sudo


### PR DESCRIPTION
Because one can "USER root" in a Dockerfile.

Keep the any_user code, it detects cases when end users are not adding a USER command, but then detect if they are not using a privileged user explicitely.