### PR TITLE
Improve root check further

### DIFF
--- a/dockerfile-security.rego
+++ b/dockerfile-security.rego
@@ -84,10 +84,10 @@ forbidden_users = [
 ]
 
 deny[msg] {
-    input[i].Cmd == "user"
-    val := input[i].Value
-    contains(lower(val[_]), forbidden_users[_])
-    msg = sprintf("Line %d: Do not run as root: %s", [i, val])
+    users := [name | input[i].Cmd == "user"; name := input[i].Value]
+    lastuser := users[count(users)-1]
+    contains(lower(lastuser[_]), forbidden_users[_])
+    msg = sprintf("Line %d: Last USER directive defined as %s is forbidden", [i, lastuser])
 }
 
 # Do not sudo

--- a/dockerfile-security.rego
+++ b/dockerfile-security.rego
@@ -84,10 +84,11 @@ forbidden_users = [
 ]
 
 deny[msg] {
+    command := "user"
     users := [name | input[i].Cmd == "user"; name := input[i].Value]
     lastuser := users[count(users)-1]
     contains(lower(lastuser[_]), forbidden_users[_])
-    msg = sprintf("Line %d: Last USER directive defined as %s is forbidden", [i, lastuser])
+    msg = sprintf("Line %d: Last USER directive (USER %s) is forbidden", [i, lastuser])
 }
 
 # Do not sudo


### PR DESCRIPTION
In follow up to #2 - I have a further improvement on disallowed root

It is perfectly acceptable to use `USER root` in some places in a Dockerfile, such as in a multi-stage build, or before running some commands which require root, as long as there is another `USER` directive after it to have the container's app itself run as non-root.

The current code fails on this incorrectly.

To work around it, we create a new array of all of the user directives specified in the Dockerfile by using an array comprehension, and then we verify that the last user in the array is not in the forbidden users list.

Signed-off-by: Thomas Spear <tspear@conquestcyber.com>