### PR TITLE
Improve suspicious env checks

### DIFF
--- a/dockerfile-security.rego
+++ b/dockerfile-security.rego
@@ -14,12 +14,38 @@ secrets_env = [
     "tkn"
 ]
 
-deny[msg] {    
-    input[i].Cmd == "env"
-    val := input[i].Value
-    contains(lower(val[_]), secrets_env[_])
-    msg = sprintf("Line %d: Potential secret in ENV key found: %s", [i, val])
+deny[msg] {
+    dockerenvs := [val | input[i].Cmd == "env"; val := input[i].Value]
+    dockerenv := dockerenvs[_]
+    envvar := dockerenv[_]
+    lower(envvar) == secrets_env[_]
+    msg = sprintf("Line %d: Potential secret in ENV key found: %s", [i, envvar])
 }
+
+deny[msg] {
+    dockerenvs := [val | input[i].Cmd == "env"; val := input[i].Value]
+    dockerenv := dockerenvs[_]
+    envvar := dockerenv[_]
+    startswith(lower(envvar), secrets_env[_])
+    msg = sprintf("Line %d: Potential secret in ENV key found: %s", [i, envvar])
+}
+
+deny[msg] {
+    dockerenvs := [val | input[i].Cmd == "env"; val := input[i].Value]
+    dockerenv := dockerenvs[_]
+    envvar := dockerenv[_]
+    endswith(lower(envvar), secrets_env[_])
+    msg = sprintf("Line %d: Potential secret in ENV key found: %s", [i, envvar])
+}
+
+deny[msg] {
+    dockerenvs := [val | input[i].Cmd == "env"; val := input[i].Value]
+    dockerenv := dockerenvs[_]
+    envvar := dockerenv[_]
+    parts := regex.split("[ :=_-]", envvar)
+    part := parts[_]
+    lower(part) == secrets_env[_]
+    msg = sprintf("Line %d: Potential secret in ENV key found: %s", [i, envvar])
 
 # Only use trusted base images
 deny[msg] {


### PR DESCRIPTION
The current check for secrets in the env commands of a Dockerfile can incorrectly flag trivially named variables used in certain image builds such as `ENV CC="/usr/bin/clang"` as potentially containing a secret.

This is due to the `contains()` function performing a substring comparison. The string "ACCESS_KEY" which is a member of the `secrets_env` array `contains` the string "CC" which causes Dockerfiles using this env variable to be flagged.

This PR improves the suspicious env check by running different checks of the env values and performing some basic parsing of the keys and values to look for anything suspicious while avoiding use of the `contains()` function

Signed-off-by: Thomas Spear <tspear@conquestcyber.com>